### PR TITLE
Change password field margin to dense in Login

### DIFF
--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -261,7 +261,7 @@ const Login = () => {
 
             {/* Password Field */}
             <TextField
-              margin="normal"
+              margin="dense"
               required
               fullWidth
               name="password"


### PR DESCRIPTION
Updated the password TextField margin from 'normal' to 'dense' in the Login page for a more compact layout.